### PR TITLE
fix: use `postFixup` phase for sha256

### DIFF
--- a/packages/vault-auth-tee/default.nix
+++ b/packages/vault-auth-tee/default.nix
@@ -24,7 +24,7 @@ pkgs.buildGoModule {
     ];
   };
 
-  postInstall = ''
+  postFixup = ''
     mkdir -p $sha/share
     sha256sum $out/bin/vault-auth-tee | (read a _; echo $a) > $sha/share/vault-auth-tee.sha256
   '';


### PR DESCRIPTION
Stripping the plugin binary in the fixup phase of course changes the hash.