### PR TITLE
chore: update extra substituter URL in nixConfig

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,11 +20,11 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
-            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            substituters = https://cache.nixos.org/ https://static.188.92.12.49.clients.your-server.de/tee-pot
       - name: Setup Attic cache
         uses: ryanccn/attic-action@v0
         with:
-          endpoint: https://attic.teepot.org/
+          endpoint: https://static.188.92.12.49.clients.your-server.de/
           cache: tee-pot
           token: ${{ secrets.ATTIC_TOKEN }}
       - run: nix flake check -L --show-trace --keep-going
@@ -38,11 +38,11 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
-            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            substituters = https://cache.nixos.org/ https://static.188.92.12.49.clients.your-server.de/tee-pot
       - name: Setup Attic cache
         uses: ryanccn/attic-action@v0
         with:
-          endpoint: https://attic.teepot.org/
+          endpoint: https://static.188.92.12.49.clients.your-server.de/
           cache: tee-pot
           token: ${{ secrets.ATTIC_TOKEN }}
       - run: nix fmt
@@ -56,11 +56,11 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
-            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            substituters = https://cache.nixos.org/ https://static.188.92.12.49.clients.your-server.de/tee-pot
       - name: Setup Attic cache
         uses: ryanccn/attic-action@v0
         with:
-          endpoint: https://attic.teepot.org/
+          endpoint: https://static.188.92.12.49.clients.your-server.de/
           cache: tee-pot
           token: ${{ secrets.ATTIC_TOKEN }}
       - name: nix build


### PR DESCRIPTION
* Replaced outdated substituter URL with a new static IP-based URL.